### PR TITLE
tcpdump: fix entrypoint path

### DIFF
--- a/tcpdump/Dockerfile
+++ b/tcpdump/Dockerfile
@@ -2,5 +2,5 @@ FROM alpine:latest
 
 RUN apk update && apk add tcpdump
 
-ENTRYPOINT ["/usr/sbin/tcpdump"]
+ENTRYPOINT ["/usr/bin/tcpdump"]
 CMD []


### PR DESCRIPTION
As of tcpdump 4.99.0, the executable is installed to bin, not sbin. See https://github.com/the-tcpdump-group/tcpdump/commit/95096be4f0c7c3efd459e3ff3bcfb526164ed446

The alpine package was updated in this commit:
https://gitlab.alpinelinux.org/alpine/aports/-/commit/8e1702e967243d0f5da7a1c4863b5be482196fcc